### PR TITLE
fix: Issue#16, resolving response data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nexios",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nexios",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nexios",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "An axios clone that wraps fetch for use with next.js.",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -153,13 +153,13 @@ describe('Nexios', () => {
 		it('should make a DELETE request with custom config', async () => {
 			mockPath += '/1';
 			mockURL += '/1';
-			const response = await nexios.delete(mockPath, customConfig);
 
 			interceptRequest(async (request) => {
 				expect(request.url).toBe(mockURL);
 				expect(request.method).toBe('DELETE');
 				expect(request.headers.get('Authorization')).toBe('Bearer TOKEN');
 			});
+			const response = await nexios.delete(mockPath, customConfig);
 
 			expect(response.status).toBe(204);
 			expect(response.data).toBe(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,10 @@ export const defaultConfig: NexiosOptions = {
 	credentials: 'include',
 	withCredentials: true,
 	cache: 'force-cache',
-	headers: { 'content-type': 'application/json', accept: 'application/json' } as NexiosHeaders,
+	headers: {
+		'content-type': 'application/json',
+		accept: 'application/json',
+	},
 	responseType: 'json',
 	// responseEncoding: 'utf8',
 	xsrfCookieName: 'XSRF-TOKEN',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { RequestMethod, Params, ResponseType, NexiosHeaders } from './types';
+import { RequestMethod, Params, ResponseContentType, NexiosHeaders } from './types';
 import NexiosResponse from './NexiosResponse';
 
 export interface NexiosOptions extends RequestInit {
@@ -33,7 +33,7 @@ export interface NexiosOptions extends RequestInit {
 		username: string;
 		password: string;
 	};
-	responseType?: ResponseType;
+	responseType?: ResponseContentType;
 	// responseEncoding?: ResponseEncoding;
 	xsrfCookieName?: string;
 	xsrfHeaderName?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type RequestMethod =
 	| 'UNLINK'
 	| (string & {});
 
-export type ResponseType =
+export type ResponseContentType =
 	| 'arraybuffer'
 	| 'blob'
 	| 'document'
@@ -46,6 +46,7 @@ export type NexiosHeaderValue = string | string[] | number | boolean | null | un
 export type ContentType =
 	| 'text/html'
 	| 'text/plain'
+	| 'text/xml'
 	| 'multipart/form-data'
 	| 'application/json'
 	| 'application/x-www-form-urlencoded'


### PR DESCRIPTION
Updated `Response.resolveBody()` to resolve the body into `response.data` based on the request's `responseType` config. Falls back to content-type header as the decider if there's a mismatch between `responseType` and `content-type`.